### PR TITLE
Enable installation into multiple namespaces

### DIFF
--- a/chart/templates/tf_controller_clusterrole.yml
+++ b/chart/templates/tf_controller_clusterrole.yml
@@ -1,3 +1,5 @@
+# Omit cluster-scoped resources if already present
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "tf-controller-clusterrole") -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -94,3 +96,4 @@ rules:
       - "create"
       - "update"
       - "delete"
+{{- end }}

--- a/chart/templates/tf_controller_clusterrolebinding.yml
+++ b/chart/templates/tf_controller_clusterrolebinding.yml
@@ -1,3 +1,5 @@
+# Omit cluster-scoped resources if already present
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "tf-controller-clusterrolebinding") -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +12,4 @@ subjects:
   - kind: ServiceAccount
     name: tf-controller-service-account
     namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
Required for nested clusters. 1 host cluster can have N nested clusters and thus N namespaces, each with its own tf-controller. The controller must be duplicated for secret isolation.

Related PRs:
- https://github.com/spectrocloud/ally/pull/951